### PR TITLE
fix(kaktwoos): use stricter boinc opencl device selection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
        echo "##[add-path]D:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\;D:\a\kaktwoos-cl\kaktwoos-cl\include\"
        g++ -w -static -m64 -Ofast -lstdc++ .\main.c -o kaktwoos-ocl.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
        g++ -w -static -m64 -Ofast -lstdc++ .\main-amd.c -o kaktwoos-ocl-amd.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
+       g++ -w -static -m64 -Ofast -lstdc++ .\main-intel.c -o kaktwoos-ocl-intel.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
+
        dir
        
     - uses: actions/upload-artifact@v2
@@ -38,8 +40,11 @@ jobs:
        ocl-icd-opencl-dev g++ libboinc7 && \
        rm -rf /var/lib/apt/lists/*
        g++ -static -w -m64 -O3 -lstdc++ ./main.c -o kaktwoos-ocl -Iboinc/ -Lboinc/lib/lin -lboinc_api -lboinc -lboinc_opencl -Wl,-Bdynamic -lpthread -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
+       g++ -static -w -m64 -O3 -lstdc++ ./main-amd.c -o kaktwoos-ocl-amd -Iboinc/ -Lboinc/lib/lin -lboinc_api -lboinc -lboinc_opencl -Wl,-Bdynamic -lpthread -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
+       g++ -static -w -m64 -O3 -lstdc++ ./main-intel.c -o kaktwoos-ocl-intel -Iboinc/ -Lboinc/lib/lin -lboinc_api -lboinc -lboinc_opencl -Wl,-Bdynamic -lpthread -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
+
        ls -la
     - uses: actions/upload-artifact@v2
       with:
        name: kaktwoos-ocl-lin
-       path: ./kaktwoos-ocl
+       path: ./kaktwoos-ocl*

--- a/main-intel.c
+++ b/main-intel.c
@@ -136,9 +136,9 @@ boinc_init_options(&options);
     cl_device_id device_ids;
     cl_int err;
 
-    // "2" here refers to AMD GPUs only
+    // "3" here refers to Intel iGPUs only
 
-    retval = boinc_get_opencl_ids(argc, argv, 2, &device_ids, &platform_id);
+    retval = boinc_get_opencl_ids(argc, argv, 3, &device_ids, &platform_id);
         if (retval) {
             fprintf(stderr, "Error: boinc_get_opencl_ids() failed with error %d\n", retval);
             return 1;


### PR DESCRIPTION
Removes the ability to do standalone testing (for now)

Each binary is now specifically configured for each GPU vendor, and will tell boinc to only run it there.

Additional testing needs to be done on both multi-gpu and multi-vendor systems to ensure this is the case.
Some computers have many tasks from a single vendor (Say 6 intel tasks and no Nvidia tasks) which may make testing slower.

fixes:#9
