### PR TITLE
feat(ci): switch to y=62 & 22+ height searches

### DIFF
--- a/kaktwoos.cl
+++ b/kaktwoos.cl
@@ -4,8 +4,8 @@ int nextIntUnknown(ulong* seed, short bound);
 unsigned char extract(const unsigned int heightMap[], int id);
 void increase(unsigned int heightMap[], int id, int val);
 
-#define WANTED_CACTUS_HEIGHT 20
-#define FLOOR_LEVEL 63
+#define WANTED_CACTUS_HEIGHT 22
+#define FLOOR_LEVEL 62
 
 kernel void crack(global int *data, global ulong* answer)
 {


### PR DESCRIPTION
We want the cactus stack to begin at y=62 and to find any cactus (super rare) 22 blocks tall or higher. 
As of Aug 2, 2020 we have begun searching with kaktoos (y=62, 7 tall) for seeds to use here. 