### PR TITLE
feat(kaktwoos): major optimizations, naming re-scheme and amd navi gpu kernel fallback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: build
       run: |
        echo "D:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\;D:\a\kaktwoos-cl\kaktwoos-cl\include\" >> $GITHUB_PATH
-       g++ -w -static -m64 -Ofast -lstdc++ .\main.c -o kaktwoos-ocl.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
+       g++ -w -static -m64 -Ofast -lstdc++ .\main-nv.c -o kaktwoos-ocl.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
        g++ -w -static -m64 -Ofast -lstdc++ .\main-amd.c -o kaktwoos-ocl-amd.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
        g++ -w -static -m64 -Ofast -lstdc++ .\main-intel.c -o kaktwoos-ocl-intel.exe -LD:\a\kaktwoos-cl\kaktwoos-cl\lib\x86_64\ -ID:\a\kaktwoos-cl\kaktwoos-cl\include\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\ -ID:\a\kaktwoos-cl\kaktwoos-cl\boinc\win\ -LD:\a\kaktwoos-cl\kaktwoos-cl\boinc\lib\win\ -lboinc_api -lboinc -lboinc_opencl -lOpenCL -D_WIN64 -DWIN64 -D_WIN32 -DWIN32 -DWANTED_CACTUS_HEIGHT=21
 
@@ -38,7 +38,7 @@ jobs:
        apt-get update && apt-get install -y \
        ocl-icd-opencl-dev g++ libc6-dev && \
        rm -rf /var/lib/apt/lists/*
-       g++ -w -m64 -O3 ./main.c -o kaktwoos-ocl-nvidia -Iboinc/ -Lboinc/lib/lin -static-libgcc -static-libstdc++ -lboinc_api -lboinc -lboinc_opencl -pthread -Wl,-Bdynamic -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
+       g++ -w -m64 -O3 ./main-nv.c -o kaktwoos-ocl-nvidia -Iboinc/ -Lboinc/lib/lin -static-libgcc -static-libstdc++ -lboinc_api -lboinc -lboinc_opencl -pthread -Wl,-Bdynamic -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
        g++ -w -m64 -O3 ./main-amd.c -o kaktwoos-ocl-amd -Iboinc/ -Lboinc/lib/lin -static-libgcc -static-libstdc++ -lboinc_api -lboinc -lboinc_opencl -pthread -Wl,-Bdynamic -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
        g++ -w -m64 -O3 ./main-intel.c -o kaktwoos-ocl-intel -Iboinc/ -Lboinc/lib/lin -static-libgcc -static-libstdc++ -lboinc_api -lboinc -lboinc_opencl -pthread -Wl,-Bdynamic -lOpenCL -Wl,-dynamic-linker,/lib64/ld-linux-x86-64.so.2 -DWANTED_CACTUS_HEIGHT=21
 

--- a/kaktwoos-amd.cl
+++ b/kaktwoos-amd.cl
@@ -1,8 +1,6 @@
 int nextInt(ulong* seed, short bound);
 int next(ulong* seed, short bits);
 int nextIntUnknown(ulong* seed, short bound);
-unsigned char extract(const unsigned int heightMap[], int id);
-void increase(unsigned int heightMap[], int id, int val);
 
 #define WANTED_CACTUS_HEIGHT 22
 kernel void crack(global int *data, global ulong* answer)
@@ -13,39 +11,38 @@ kernel void crack(global int *data, global ulong* answer)
 	short position = -1;
 	short posMap;
 	short posX, posY, posZ;
-	short initialPosX, initialPosY, initialPosZ, initialPos;
-	short top = data[7];
+	short initialPosX, initialPosY, initialPosZ;
+	uchar top = data[7] + FLOOR_LEVEL;
 
-	uint heightMap[205];
+	uchar heightMap[1024];
 
-	for (short i = 0; i < 205; i++) {
-		heightMap[i] = 0;
+	for (short i = 0; i < 1024; i++) {
+		heightMap[i] = FLOOR_LEVEL;
 	}
 
 	for (short i = 0; i < 10; i++) {
-		if (WANTED_CACTUS_HEIGHT - top > 9 * (10 - i)) {
+		if (WANTED_CACTUS_HEIGHT - top > 9 * (10 - i) + FLOOR_LEVEL)
 			return;
-		}
 
 		initialPosX = next(&seed, 4) + 8;
 		initialPosZ = next(&seed, 4) + 8;
-		initialPos = initialPosX + initialPosZ * 32;
 
-		short terrainHeight = (extract(heightMap, initialPos) + FLOOR_LEVEL + 1) * 2;
+		short terrainHeight = heightMap[initialPosX + initialPosZ * 32] * 2 + 2;
 		initialPosY = nextIntUnknown(&seed, terrainHeight);
 
 		if (initialPosY + 3 <= FLOOR_LEVEL && initialPosY - 3 >= 0) {
 			seed = (seed * 256682821044977UL + 233843537749372UL) & ((1UL << 48) - 1);
 			continue;
 		}
-		if (initialPosY - 3 > top + FLOOR_LEVEL + 1) {
+		
+		if (initialPosY - 3 > top + 1) {
 			for (int j = 0; j < 10; j++) {
 				seed = (seed * 76790647859193UL + 25707281917278UL) & ((1UL << 48) - 1);
 				nextIntUnknown(&seed, nextInt(&seed, 3) + 1);
 			}
 			continue;
 		}
-
+#pragma unroll (2)
 		for (short a = 0; a < 10; a++) {
 			posX = initialPosX + next(&seed, 3) - next(&seed, 3);
 			posY = initialPosY + next(&seed, 2) - next(&seed, 2);
@@ -64,40 +61,36 @@ kernel void crack(global int *data, global ulong* answer)
 				if (position != -1) {
 					int bit = (int)((originalSeed >> 4) & 1);
 
-					if (data[6] != position) {
-						if (bit == data[9]) return;
-					} else {
-						if (bit != data[9]) return;
-					}
+					if ((data[6] == position) ^ (bit == data[9]))
+						return;
 
-					increase(heightMap, posMap, data[7]);
-					top = data[7];
+					heightMap[posMap] += data[7];
 				}
 			}
 
-			if (posY <= extract(heightMap, posMap) + FLOOR_LEVEL) continue;
+			if (posY <= heightMap[posMap])
+				continue;
 
 			short offset = 1 + nextIntUnknown(&seed, nextInt(&seed, 3) + 1);
-
-			for (short j = 0; j < offset; j++) {
-				if ((posY + j - 1) > extract(heightMap, posX + posZ * 32) + FLOOR_LEVEL || posY < 0) continue;
-				if ((posY + j) <= extract(heightMap, (posX + 1) + posZ * 32) + FLOOR_LEVEL) continue;
-				if ((posY + j) <= extract(heightMap, (posX - 1) + posZ * 32) + FLOOR_LEVEL) continue;
-				if ((posY + j) <= extract(heightMap, posX + (posZ + 1) * 32) + FLOOR_LEVEL) continue;
-				if ((posY + j) <= extract(heightMap, posX + (posZ - 1) * 32) + FLOOR_LEVEL) continue;
-
-				increase(heightMap, posMap, 1);
-
-				if (top < extract(heightMap, posMap)) {
-					top = extract(heightMap, posMap);
-				}
+#pragma unroll (4)
+			for (uchar j = posY; j < posY + offset; j++) {
+				if (posY < 0 ||
+					j >  heightMap[posMap] + 1  ||
+					j <= heightMap[posMap + 1 ] ||
+					j <= heightMap[posMap - 1 ] ||
+					j <= heightMap[posMap + 32] ||
+					j <= heightMap[posMap - 32])
+					continue;
+				
+				heightMap[posMap]++;
 			}
+			top = max(top, heightMap[posMap]);
 		}
 
 	}
-	if (top >= WANTED_CACTUS_HEIGHT) {
+	if (top - FLOOR_LEVEL >= WANTED_CACTUS_HEIGHT) {
 		answer[atomic_add(&data[2], 1)] =
-				((ulong)top) << 58UL |
+				((ulong)top - FLOOR_LEVEL) << 58UL |
 				(((ulong)data[position + 3]) << 48UL) |
 				originalSeed;
 	}
@@ -134,15 +127,5 @@ int nextIntUnknown(ulong* seed, short bound)
 		value = bits % bound;
 	} while(bits - value + (bound - 1) < 0);
 	return value;
-}
-
-unsigned char extract(const unsigned int heightMap[], int id)
-{
-	return (heightMap[id / 5] >> ((id % 5) * 6)) & 0b111111U;
-}
-
-void increase(unsigned int heightMap[], int id, int val)
-{
-	heightMap[id / 5] += val << ((id % 5) * 6);
 }
 

--- a/kaktwoos-nv.cl
+++ b/kaktwoos-nv.cl
@@ -1,0 +1,150 @@
+#define MASK ((1UL << 48UL) - 1UL)
+#define MUL 0x5DEECE66DUL
+#define ADD 0xBUL
+
+#define WANTED_CACTUS_HEIGHT 22
+
+int nextInt(ulong* seed);
+int next(ulong* seed, short bits);
+int nextIntUnknown(ulong* seed, short bound);
+
+uchar extract(const uint heightMap[], int id);
+void increase(uint heightMap[], int id, int val);
+
+kernel void crack(global int *data, global ulong* answer)
+{
+    int id = get_global_id(0);
+    ulong originalSeed = (((ulong)data[0] * (ulong)data[1] + (ulong)id) << 4) | data[8];
+    ulong seed = originalSeed;
+    short position = -1;
+    short posMap;
+    short posX, posY, posZ;
+    short initialPosX, initialPosY, initialPosZ;
+    uchar top = data[7] + FLOOR_LEVEL;
+
+    uint heightMap[171];
+
+    for (short i = 0; i < 171; i++) {
+        heightMap[i] = 0;
+    }
+
+    for (short i = 0; i < 10; i++) {
+        if (WANTED_CACTUS_HEIGHT - top > 9 * (10 - i))
+            return;
+
+        initialPosX = next(&seed, 4) + 8;
+        initialPosZ = next(&seed, 4) + 8;
+
+        initialPosY = nextIntUnknown(&seed, extract(heightMap, initialPosX + initialPosZ * 32) * 2 + 2);
+
+        if (initialPosY + 3 <= FLOOR_LEVEL && initialPosY - 3 >= 0) {
+            seed = (seed * 256682821044977UL + 233843537749372UL) & MASK;
+            continue;
+        }
+        
+        if (initialPosY - 3 > top + 1) {
+            for (int j = 0; j < 10; j++) {
+                seed = (seed * 76790647859193UL + 25707281917278UL) & MASK;
+                nextIntUnknown(&seed, nextInt(&seed) + 1);
+            }
+            continue;
+        }
+        
+#pragma unroll (1)
+        for (short a = 0; a < 10; a++) {
+            posX = initialPosX + next(&seed, 3) - next(&seed, 3);
+            posY = initialPosY + next(&seed, 2) - next(&seed, 2);
+            posZ = initialPosZ + next(&seed, 3) - next(&seed, 3);
+            posMap = posX + posZ * 32;
+
+            if (position == -1 && posY > FLOOR_LEVEL && posY <= FLOOR_LEVEL + data[7] + 1) {
+                if (posMap == data[3]) {
+                    position = 0;
+                } else if (posMap == data[4]) {
+                    position = 1;
+                } else if (posMap == data[5]) {
+                    position = 2;
+                }
+
+                if (position != -1) {
+                    int bit = (int)((originalSeed >> 4) & 1);
+
+                    if ((data[6] == position) ^ (bit == data[9]))
+                        return;
+
+                    increase(heightMap, posMap, data[7]);
+                }
+            }
+
+            if (posY <= extract(heightMap, posMap))
+                continue;
+
+            short offset = 1 + nextIntUnknown(&seed, nextInt(&seed) + 1);
+
+            for (uchar j = posY; j < posY + offset; j++) {
+                if (posY < 0 ||
+                    j >  extract(heightMap, posMap) + 1  ||
+                    j <= extract(heightMap, (posMap + 1 ) & 1023) ||
+                    j <= extract(heightMap, (posMap - 1 ) & 1023) ||
+                    j <= extract(heightMap, (posMap + 32) & 1023) ||
+                    j <= extract(heightMap, (posMap - 32) & 1023))
+                    continue;
+                
+                increase(heightMap, posMap, 1);
+            }
+            top = max(top, extract(heightMap, posMap));
+        }
+
+    }
+    if (top - FLOOR_LEVEL >= WANTED_CACTUS_HEIGHT) {
+        answer[atomic_add(&data[2], 1)] =
+                ((ulong)top - FLOOR_LEVEL) << 58UL |
+                (((ulong)data[position + 3]) << 48UL) |
+                originalSeed;
+    }
+}
+
+int next(ulong* seed, short bits)
+{
+    *seed = (*seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1);
+    return *seed >> (48 - bits);
+}
+
+int nextInt(ulong* seed)
+{
+    int bits, value;
+    do {
+        *seed = (*seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1);
+        bits = *seed >> 17;
+        value = bits % 3;
+    } while(bits - value + (3 - 1) < 0);
+    return value;
+}
+
+int nextIntUnknown(ulong* seed, short bound)
+{
+    if((bound & -bound) == bound) {
+        *seed = (*seed * MUL + ADD) & MASK;
+        return (int)((bound * (*seed >> 17)) >> 31);
+    }
+
+    int bits, value;
+    do {
+        *seed = (*seed * MUL + ADD) & MASK;
+        bits = *seed >> 17;
+        value = bits % bound;
+    } while(bits - value + (bound - 1) < 0);
+    return value;
+}
+
+uchar extract(const uint heightMap[], int id)
+{
+    return FLOOR_LEVEL + ((heightMap[id / 6] >> ((id % 6) * 5)) & 0b11111U);
+}
+
+void increase(uint heightMap[], int id, int val)
+{
+    heightMap[id / 6] += val << ((id % 6) * 5);
+}
+
+

--- a/main-amd.c
+++ b/main-amd.c
@@ -127,17 +127,6 @@ boinc_set_min_checkpoint_period(30);
 
 	fflush(stderr);
 
-    FILE *kernel_file = boinc_fopen("kaktwoos.cl", "r");
-    if (!kernel_file) {
-        printf("Failed to open kernel");
-        exit(1);
-    }
-
-    char *kernel_src = (char *)malloc(KERNEL_BUFFER_SIZE);
-    size_t kernel_length = fread(kernel_src, 1, KERNEL_BUFFER_SIZE, kernel_file);
-
-    fclose(kernel_file);
-
     cl_platform_id platform_id = NULL;
     cl_device_id device_ids;
     cl_int err;
@@ -145,6 +134,8 @@ boinc_set_min_checkpoint_period(30);
     num_devices_standalone = 1;
     cl_uint num_entries;
     num_entries = 1;
+    const char* kernel_name = "kaktwoos-amd.cl";
+
     // Third arg has 2 for AMD
     retval = boinc_get_opencl_ids(argc, argv, 2, &device_ids, &platform_id);
         if (retval) {
@@ -161,6 +152,41 @@ boinc_set_min_checkpoint_period(30);
                 return 1;
             }
         }
+
+    char buffer[1024];
+    char *navi10="gfx1010";
+    char *navi12="gfx1012";
+    char *navi21="gfx1030"; // Yes, RDNA2 is Navi 21, but GFX1030
+
+    clGetDeviceInfo(device_ids, CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
+    //fprintf(stderr,"DEVICE_NAME = %s\n", buffer);
+
+    if (strcmp(navi10, buffer) == 0 ) {
+        printf("GPU Navi 10, compat time");
+        kernel_name = "kaktwoos.cl";
+        }
+
+    if (strcmp(navi12, buffer) == 0 ) {
+        printf("GPU Navi 12, compat time");
+        kernel_name = "kaktwoos.cl";
+        }
+
+    if (strcmp(navi21, buffer) == 0 ) {
+         printf("GPU Navi 21, compat time");
+         kernel_name = "kaktwoos.cl";
+        }
+
+
+    FILE *kernel_file = boinc_fopen(kernel_name, "r");
+    if (!kernel_file) {
+        fprintf(stderr,"Failed to open kernel");
+        exit(1);
+    }
+
+    char *kernel_src = (char *)malloc(KERNEL_BUFFER_SIZE);
+    size_t kernel_length = fread(kernel_src, 1, KERNEL_BUFFER_SIZE, kernel_file);
+
+    fclose(kernel_file);
 
     cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties)platform_id, 0};
 

--- a/main-intel.c
+++ b/main-intel.c
@@ -129,7 +129,7 @@ boinc_set_min_checkpoint_period(30);
 
     FILE *kernel_file = boinc_fopen("kaktwoos.cl", "r");
     if (!kernel_file) {
-        printf("Failed to open kernel");
+        fprintf(stderr,"Failed to open kernel");
         exit(1);
     }
 

--- a/main-nv.c
+++ b/main-nv.c
@@ -127,9 +127,9 @@ boinc_set_min_checkpoint_period(30);
 
 	fflush(stderr);
 
-    FILE *kernel_file = boinc_fopen("kaktwoos.cl", "r");
+    FILE *kernel_file = boinc_fopen("kaktwoos-nv.cl", "r");
     if (!kernel_file) {
-        printf("Failed to open kernel");
+        fprintf(stderr,"Failed to open kernel");
         exit(1);
     }
 
@@ -162,7 +162,7 @@ boinc_set_min_checkpoint_period(30);
                 return 1;
             }
         }
-    
+
     cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties)platform_id, 0};
 
     cl_context context = clCreateContext(cps, 1, &device_ids, NULL, NULL, &err);


### PR DESCRIPTION
With @BalintCsala and his changes to our Opencl kernel, we get roughly 15-20% more performance when running Kaktwoos, but some GPUs benefit this more than others...
Edit: Kernels have been split up and fallback code added for AMD RDNA/RDNA2 gpus!

"kaktwoos-amd.cl"
RX 5600XT (73m/s, using original kernel. Optimizations disabled by check in main-amd.c)
Vega 56 went from 42 -> 63m/s (million seeds a second) (+50%!)
RX 480 went from 17 -> 25m/s (+30%!)
r5 540M went from 3.9 -> 5.35m/s (+30%!)
R5 4600H APU has no negative performance, slight potential boost too.

"kaktwoos-nv.cl"
RTX 3090 went from 225 -> 232m/s (+5%?)
RTX 2060 went from 52 -> 80m/s (+60%)
GTX 1650M went from 50 -> 52m/s (+5%)
GTX 1080ti went from 61 -> 58.4m/s (-3%) (might be due to more kernel printing, or heating?)
GTX 1070 had no change in perf, 53.3m/s

Intel remains on the old unoptimized kernel, as any changes in the past have not helped it much.

Please verify seeds and outputs further
All changes will be boinc version.xml side and in kaktwoos repo. Binaries now attempt to load their corresponding kernel by default (and thus BOINC's version.xml config has been adjusted to ensure these are loaded instead)