### PR TITLE
fix(kaktwoos): nvidia-name inconsistency and start-end print fixes

### DIFF
--- a/main-amd.c
+++ b/main-amd.c
@@ -115,7 +115,8 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Received work unit: %"
     SCNd64
     "\n", chunkSeed);
-    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %SCNd64, e: %SCNd64 \n",
+
+    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %" SCNd64 ", e: %" SCNd64 "\n",
             neighbor1,
             neighbor2,
             neighbor3,

--- a/main-amd.c
+++ b/main-amd.c
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
     char *navi = "gfx10";
 
     clGetDeviceInfo(device_ids, CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
-    //fprintf(stderr,"DEVICE_NAME = %s\n", buffer);
+    fprintf(stderr,"DEVICE_NAME = %s\n", buffer);
 
     buffer[5] = '\0';
     if (strcmp(navi, buffer) == 0 ) {

--- a/main-intel.c
+++ b/main-intel.c
@@ -199,10 +199,10 @@ int main(int argc, char *argv[]) {
             (const char **) &kernel_src,
             &kernel_length,
             &err);
+
     check(err, "clCreateProgramWithSource ");
     char *opt = (char *) malloc(20 * sizeof(char));
     sprintf(opt, "-DFLOOR_LEVEL=%d", floor_level);
-    printf("Test: %s if there's nothing before this then fucking hell", opt);
     err = clBuildProgram(program, 1, &device_ids, opt, NULL, NULL);
 
     if (err != CL_SUCCESS) {

--- a/main-intel.c
+++ b/main-intel.c
@@ -115,7 +115,8 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Received work unit: %"
     SCNd64
     "\n", chunkSeed);
-    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %SCNd64, e: %SCNd64 \n",
+
+    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %" SCNd64 ", e: %" SCNd64 "\n",
             neighbor1,
             neighbor2,
             neighbor3,

--- a/main-nv.c
+++ b/main-nv.c
@@ -167,13 +167,18 @@ int main(int argc, char *argv[]) {
     }
 
     char buffer[1024]; // Buffer to store rec'd GPU chip
-    char *rtx="RTX"; // CASE SENSITIVE?
+    char *rtx="RTX"; // CASE SENSITIVE
     char *gtx16="GTX 16";
 
     clGetDeviceInfo(device_ids, CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
     fprintf(stderr,"DEVICE_NAME = %s\n", buffer);
 
-    char* tmpBuffer = buffer+8;
+    if ( 'N' == buffer[0] ){
+    char* tmpBuffer = buffer+15;
+    } else {
+    char* tmpBuffer = buffer+8; // buffer+8 for GeForce name, +15 for Nvidia Geforce
+    }
+
     tmpBuffer[3] = '\0';
     if (strcmp(rtx, tmpBuffer) == 0 ) {
         kernel_name = "kaktwoos-nv.cl";

--- a/main-nv.c
+++ b/main-nv.c
@@ -115,7 +115,8 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Received work unit: %"
     SCNd64
     "\n", chunkSeed);
-    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %SCNd64, e: %SCNd64 \n",
+
+    fprintf(stderr, "Data: n1: %d, n2: %d, n3: %d, di: %d, ch: %d, f: %d, s: %" SCNd64 ", e: %" SCNd64 "\n",
             neighbor1,
             neighbor2,
             neighbor3,
@@ -173,10 +174,11 @@ int main(int argc, char *argv[]) {
     clGetDeviceInfo(device_ids, CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
     fprintf(stderr,"DEVICE_NAME = %s\n", buffer);
 
+    char* tmpBuffer;
     if ( 'N' == buffer[0] ){
-    char* tmpBuffer = buffer+15;
+    tmpBuffer = buffer+15;
     } else {
-    char* tmpBuffer = buffer+8; // buffer+8 for GeForce name, +15 for Nvidia Geforce
+    tmpBuffer = buffer+8; // buffer+8 for GeForce name, +15 for Nvidia Geforce
     }
 
     tmpBuffer[3] = '\0';


### PR DESCRIPTION
Nvidia has decided that some gpus are named "GeForce GTX" while others are "NVIDIA GeForce RTX/GTX", meaning the Nvidia optimization toggle won't always catch the device name properly.

This should hopefully mean it always begins the char-compare for the character after the space in GEFORCE

Also, AMD cards will now print their GPU name, which is "GFX900" on Vega for example.